### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,26 @@ exec: &exec
 version: 2.1
 
 orbs:
-  build-tools: nerves-project/build-tools@0.1.2
+  build-tools: nerves-project/build-tools@0.2.2
 
 workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - build-tools/build-system:
+      - build-tools/get-br-dependencies:
           exec:
             <<: *exec
           context: nerves-build
+          filters:
+            tags:
+              only: /.*/
+      - build-tools/build-system:
+          exec:
+            <<: *exec
+          resource-class: large
+          context: nerves-build
+          requires:
+            - build-tools/get-br-dependencies
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This PR upgrades the Nerves build tools to `0.2.2` and updates the CircleCI config to take advantage of fetching the Buildroot dependencies in a step before the build.