### PR TITLE
Add package download site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
           exec:
             <<: *exec
           context: nerves-build
+          download-site-url: http://dl.alexmclain.com
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This PR adds a [package download site](https://github.com/nerves-project/build-tools#package-download-sites) for this Nerves system to cache buildroot assets. Unit tests are expected to fail because there are no changes for the system to compile. CI was tested [here](https://app.circleci.com/pipelines/github/amclain/nerves_system_sama5d27_wlsom1_ek/39/workflows/11bcdbcf-4c52-4e4c-90e4-6df910147602/jobs/73).