### PR TITLE
Configure board ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,16 @@ file location by setting the environment variable
 `NERVES_PROVISIONING=/path/to/provisioning.conf`. The default provisioning.conf
 will set the `nerves_serial_number`, if you override the location to this file,
 you will be responsible for setting this yourself.
+
+## Hostname
+
+By default the hostname will only include the last 4 digits of the board
+identifier. If you would rather use the entire identifier, set the following
+in your `config/target.exs` file:
+
+```elixir
+config :nerves,
+  erlinit: [
+    uniqueid_exec: "boardid"
+  ]
+```

--- a/rootfs_overlay/etc/boardid.config
+++ b/rootfs_overlay/etc/boardid.config
@@ -1,0 +1,9 @@
+# Check if a serial number has been manually set with the nerves_serial_number
+# U-Boot environment variable.
+-b uboot_env -u nerves_serial_number
+
+# Get the board identifier from the ATECC Trust&GO crypto chip if using the SOM.
+-b atecc508a -X -a 0x35 -f /dev/i2c-0
+
+# Fall back to using the MAC address.
+-b macaddr

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -57,10 +57,9 @@
 # Erlang release search path
 -r /srv/erlang
 
-# Assign a unique hostname based on a board identifier. The logic is:
-# 1. Check the U-boot environment block for a key named "nerves_serial_number"
-# 2. Use the MAC address of the first Ethernet port.
--d "/usr/bin/boardid -b uboot_env -u nerves_serial_number -b macaddr -n 4"
+# Assign a unique hostname based on a board identifier.
+# See `/etc/boardid.config` for how the identifier is determined.
+-d /usr/bin/boardid -n 4
 -n nerves-%s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the


### PR DESCRIPTION
This PR adds a `boardid.config` file to move the config out of `erlinit.config` and make further calls to `boardid` repeatable. It also checks for the presence of the Microchip SOM's ATECC crypto chip and uses its serial number if it exists.