### PR TITLE
Fwup conf refactor

### DIFF
--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -83,9 +83,9 @@ task revert.a {
     on-init {
         info("Reverting to partition A")
 
-	# Switch over
+        # Switch over
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
-	uboot_setenv(uboot-env, "nerves_fw_validated", "1")
+        uboot_setenv(uboot-env, "nerves_fw_validated", "1")
     }
 }
 
@@ -100,9 +100,9 @@ task revert.b {
     on-init {
         info("Reverting to partition B")
 
-	# Switch over
+        # Switch over
         uboot_setenv(uboot-env, "nerves_fw_active", "b")
-	uboot_setenv(uboot-env, "nerves_fw_validated", "1")
+        uboot_setenv(uboot-env, "nerves_fw_validated", "1")
     }
 }
 

--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -8,69 +8,10 @@
 #      it succeeds, reboot. If not, then it's possible that there isn't a previous
 #      firmware or the metadata about what's stored where is corrupt or out of
 #      sync.
-#
-# It is critical that this is kept in sync with the main fwup.conf.
 
 require-fwup-version="1.0.0"
 
-#
-# Firmware metadata
-#
-
-# All of these can be overriden using environment variables of the same name.
-#
-#  Run 'fwup -m' to query values in a .fw file.
-#  Use 'fw_printenv' to query values on the target.
-#
-# These are used by Nerves libraries to introspect.
-define(NERVES_FW_PRODUCT, "Nerves Firmware")
-define(NERVES_FW_DESCRIPTION, "")
-define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
-define(NERVES_FW_PLATFORM, "sama5d27")
-define(NERVES_FW_ARCHITECTURE, "arm")
-define(NERVES_FW_AUTHOR, "The Nerves Team")
-
-# This configuration file will create an image that
-# has an MBR and the following layout:
-#
-# +----------------------------+
-# | MBR                        |
-# +----------------------------+
-# | Firmware configuration data|
-# | (formatted as uboot env)   |
-# +----------------------------+
-# | p0: Boot partition (FAT32) |
-# | u-boot.img                 |
-# | zImage.a                   |
-# | zImage.b                   |
-# +----------------------------+
-# | p1: Rootfs A (squashfs)    |
-# +----------------------------+
-# | p2: Rootfs B (squashfs)    |
-# +----------------------------+
-# | p3: Application (f2fs)     |
-# +----------------------------+
-
-# The U-Boot environment is written directly to the SDCard/eMMC. It is not
-# in any partition
-define(UBOOT_ENV_OFFSET, 2048)
-define(UBOOT_ENV_COUNT, 256)  # 128 KB
-
-# Firmware archive metadata
-meta-product = ${NERVES_FW_PRODUCT}
-meta-description = ${NERVES_FW_DESCRIPTION}
-meta-version = ${NERVES_FW_VERSION}
-meta-platform = ${NERVES_FW_PLATFORM}
-meta-architecture = ${NERVES_FW_ARCHITECTURE}
-meta-author = ${NERVES_FW_AUTHOR}
-meta-vcs-identifier = ${NERVES_FW_VCS_IDENTIFIER}
-meta-misc = ${NERVES_FW_MISC}
-
-# Location where installed firmware information is stored.
-uboot-environment uboot-env {
-    block-offset = ${UBOOT_ENV_OFFSET}
-    block-count = ${UBOOT_ENV_COUNT}
-}
+include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
 task revert.a {
     # This task reverts to the A partition, so check that we're running on B
@@ -131,22 +72,22 @@ task revert.wrongplatform {
 
 # Run "fwup /usr/share/fwup/revert.fw -t status -d /dev/mmcblk0 -q -U" to check the status.
 task status.aa {
-    require-path-on-device("/", "/dev/mmcblk0p2")
+    require-path-on-device("/", "${ROOTFS_A_DEV}")
     require-uboot-variable(uboot-env, "nerves_fw_active", "a")
     on-init { info("a") }
 }
 task status.ab {
-    require-path-on-device("/", "/dev/mmcblk0p2")
+    require-path-on-device("/", "${ROOTFS_A_DEV}")
     require-uboot-variable(uboot-env, "nerves_fw_active", "b")
     on-init { info("a->b") }
 }
 task status.bb {
-    require-path-on-device("/", "/dev/mmcblk0p3")
+    require-path-on-device("/", "${ROOTFS_B_DEV}")
     require-uboot-variable(uboot-env, "nerves_fw_active", "b")
     on-init { info("b") }
 }
 task status.ba {
-    require-path-on-device("/", "/dev/mmcblk0p3")
+    require-path-on-device("/", "${ROOTFS_B_DEV}")
     require-uboot-variable(uboot-env, "nerves_fw_active", "a")
     on-init { info("b->a") }
 }

--- a/fwup.conf
+++ b/fwup.conf
@@ -2,95 +2,19 @@
 
 require-fwup-version="1.0.0"
 
-#
-# Firmware metadata
-#
-
-# All of these can be overriden using environment variables of the same name.
-#
-#  Run 'fwup -m' to query values in a .fw file.
-#  Use 'fw_printenv' to query values on the target.
-#
-# These are used by Nerves libraries to introspect.
-define(NERVES_FW_PRODUCT, "Nerves Firmware")
-define(NERVES_FW_DESCRIPTION, "")
-define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
-define(NERVES_FW_PLATFORM, "sama5d27")
-define(NERVES_FW_ARCHITECTURE, "arm")
-define(NERVES_FW_AUTHOR, "The Nerves Team")
-
-define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
-define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p4") # Linux part number is 1-based
-define(NERVES_FW_APPLICATION_PART0_FSTYPE, "f2fs")
-define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
-define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.conf")
-
-# Default paths if not specified via the commandline
-define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
-
-# This configuration file will create an image that
-# has an MBR and the following layout:
-#
-# +----------------------------+
-# | MBR                        |
-# +----------------------------+
-# | Firmware configuration data|
-# | (formatted as uboot env)   |
-# +----------------------------+
-# | sama5d27 bootstrap code    |
-# +----------------------------+
-# | p0: Boot partition (FAT32) |
-# | u-boot.img                 |
-# +----------------------------+
-# | p1: Rootfs A (squashfs)    |
-# +----------------------------+
-# | p2: Rootfs B (squashfs)    |
-# +----------------------------+
-# | p3: Application (f2fs)     |
-# +----------------------------+
-#
-# The U-Boot environment is written directly to the SDCard/eMMC. It is not
-# in any partition
-define(UBOOT_ENV_OFFSET, 2048)
-define(UBOOT_ENV_COUNT, 256)  # 128 KB
-
-# The boot partition contains MLO, u-boot.img, and zImage
-define(BOOT_PART_OFFSET, 4096)
-define(BOOT_PART_COUNT, 28672)
-
-# Let the rootfs have room to grow up to 140 MiB and align it to the nearest 1
-# MB boundary
-define(ROOTFS_A_PART_OFFSET, 63488)
-define(ROOTFS_A_PART_COUNT, 286720)
-define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
-define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
-
-# Application partition. This partition can occupy all of the remaining space.
-# Size it to fit the destination.
-define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
-define(APP_PART_COUNT, 1048576)
-
-# Firmware archive metadata
-meta-product = ${NERVES_FW_PRODUCT}
-meta-description = ${NERVES_FW_DESCRIPTION}
-meta-version = ${NERVES_FW_VERSION}
-meta-platform = ${NERVES_FW_PLATFORM}
-meta-architecture = ${NERVES_FW_ARCHITECTURE}
-meta-author = ${NERVES_FW_AUTHOR}
-meta-vcs-identifier = ${NERVES_FW_VCS_IDENTIFIER}
-meta-misc = ${NERVES_FW_MISC}
+include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
 # File resources are listed in the order that they are included in the .fw file
 # This is important, since this is the order that they're written on a firmware
 # update due to the event driven nature of the update system.
 file-resource boot.bin {
-    host-path = "${NERVES_SYSTEM}/images/boot.bin"
+    host-path = "${NERVES_SDK_IMAGES}/boot.bin"
 }
 file-resource u-boot.bin {
-    host-path = "${NERVES_SYSTEM}/images/u-boot.bin"
+    host-path = "${NERVES_SDK_IMAGES}/u-boot.bin"
 }
 file-resource uboot-env.bin {
-    host-path = "${NERVES_SYSTEM}/images/uboot-env.bin"
+    host-path = "${NERVES_SDK_IMAGES}/uboot-env.bin"
 }
 file-resource rootfs.img {
     host-path = ${ROOTFS}
@@ -100,7 +24,7 @@ file-resource rootfs.img {
 }
 
 mbr mbr {
-    bootstrap-code-host-path = "${NERVES_SYSTEM}/images/sama5d2-sdcardboot-uboot-4.0.5.bin"
+    bootstrap-code-host-path = "${NERVES_SDK_IMAGES}/sama5d2-sdcardboot-uboot-4.0.5.bin"
     partition 0 {
         block-offset = ${BOOT_PART_OFFSET}
         block-count = ${BOOT_PART_COUNT}
@@ -123,14 +47,6 @@ mbr mbr {
         type = 0x83 # Linux
         expand = true
     }
-}
-
-# Location where installed firmware information is stored.
-# While this is called "u-boot", u-boot isn't involved in this
-# setup. It just provides a convenient key/value store format.
-uboot-environment uboot-env {
-    block-offset = ${UBOOT_ENV_OFFSET}
-    block-count = ${UBOOT_ENV_COUNT}
 }
 
 # This firmware task writes everything to the destination media

--- a/fwup.conf
+++ b/fwup.conf
@@ -234,7 +234,7 @@ task upgrade.a {
         uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
         uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
 
-	      # Reset the validation status and boot to A
+        # Reset the validation status and boot to A
         # next time.
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
         uboot_setenv(uboot-env, "nerves_fw_validated", "0")
@@ -284,7 +284,7 @@ task upgrade.b {
         uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
         uboot_setenv(uboot-env, "b.nerves_fw_uuid", "\${FWUP_META_UUID}")
 
-	      # Reset the validation status and boot to B next time.
+        # Reset the validation status and boot to B next time.
         uboot_setenv(uboot-env, "nerves_fw_active", "b")
         uboot_setenv(uboot-env, "nerves_fw_validated", "0")
         uboot_setenv(uboot-env, "nerves_fw_booted", "0")

--- a/fwup_include/fwup-common.conf
+++ b/fwup_include/fwup-common.conf
@@ -1,0 +1,87 @@
+#
+# Firmware metadata
+#
+
+# All of these can be overriden using environment variables of the same name.
+#
+#  Run 'fwup -m' to query values in a .fw file.
+#  Use 'fw_printenv' to query values on the target.
+#
+# These are used by Nerves libraries to introspect.
+define(NERVES_FW_PRODUCT, "Nerves Firmware")
+define(NERVES_FW_DESCRIPTION, "")
+define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
+define(NERVES_FW_PLATFORM, "sama5d27")
+define(NERVES_FW_ARCHITECTURE, "arm")
+define(NERVES_FW_AUTHOR, "The Nerves Team")
+
+define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
+define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p4") # Linux part number is 1-based
+define(NERVES_FW_APPLICATION_PART0_FSTYPE, "f2fs")
+define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
+define(NERVES_PROVISIONING, "${NERVES_SDK_IMAGES}/fwup_include/provisioning.conf")
+
+# Default paths if not specified via the commandline
+define(ROOTFS, "${NERVES_SDK_IMAGES}/rootfs.squashfs")
+
+# This configuration file will create an image that
+# has an MBR and the following layout:
+#
+# +----------------------------+
+# | MBR                        |
+# +----------------------------+
+# | Firmware configuration data|
+# | (formatted as uboot env)   |
+# +----------------------------+
+# | sama5d27 bootstrap code    |
+# +----------------------------+
+# | p0: Boot partition (FAT32) |
+# | u-boot.img                 |
+# +----------------------------+
+# | p1: Rootfs A (squashfs)    |
+# +----------------------------+
+# | p2: Rootfs B (squashfs)    |
+# +----------------------------+
+# | p3: Application (f2fs)     |
+# +----------------------------+
+#
+# The U-Boot environment is written directly to the SDCard/eMMC. It is not
+# in any partition
+define(UBOOT_ENV_OFFSET, 2048)
+define(UBOOT_ENV_COUNT, 256)  # 128 KB
+
+# The boot partition contains MLO, u-boot.img, and zImage
+define(BOOT_PART_OFFSET, 4096)
+define(BOOT_PART_COUNT, 28672)
+
+# Let the rootfs have room to grow up to 140 MiB and align it to the nearest 1
+# MB boundary
+define(ROOTFS_A_PART_OFFSET, 63488)
+define(ROOTFS_A_PART_COUNT, 286720)
+define(ROOTFS_A_DEV, "/dev/mmcblk0p2")
+define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
+define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
+define(ROOTFS_B_DEV, "/dev/mmcblk0p3")
+
+# Application partition. This partition can occupy all of the remaining space.
+# Size it to fit the destination.
+define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
+define(APP_PART_COUNT, 1048576)
+
+# Firmware archive metadata
+meta-product = ${NERVES_FW_PRODUCT}
+meta-description = ${NERVES_FW_DESCRIPTION}
+meta-version = ${NERVES_FW_VERSION}
+meta-platform = ${NERVES_FW_PLATFORM}
+meta-architecture = ${NERVES_FW_ARCHITECTURE}
+meta-author = ${NERVES_FW_AUTHOR}
+meta-vcs-identifier = ${NERVES_FW_VCS_IDENTIFIER}
+meta-misc = ${NERVES_FW_MISC}
+
+# Location where installed firmware information is stored.
+# While this is called "u-boot", u-boot isn't involved in this
+# setup. It just provides a convenient key/value store format.
+uboot-environment uboot-env {
+    block-offset = ${UBOOT_ENV_OFFSET}
+    block-count = ${UBOOT_ENV_COUNT}
+}


### PR DESCRIPTION
There are duplicate info in fwup.conf and fwup-revert.conf than must be kept in sync. This PR refactors the common elements to fwup_include/fwup-common.conf so that this issue is no longer a concern